### PR TITLE
feat: [iOS] load image buffer before creating stream

### DIFF
--- a/ios/RCTWebRTC.xcodeproj/project.pbxproj
+++ b/ios/RCTWebRTC.xcodeproj/project.pbxproj
@@ -8,8 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0BDDA6E020C18B6B00B38B45 /* VideoCaptureController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BDDA6DF20C18B6B00B38B45 /* VideoCaptureController.m */; };
-		474EDB052E4BAA5E00E04760 /* FileCaptureController.m in Sources */ = {isa = PBXBuildFile; fileRef = 474EDB022E4BAA5E00E04760 /* FileCaptureController.m */; };
-		474EDB062E4BAA5E00E04760 /* FileCapturer.m in Sources */ = {isa = PBXBuildFile; fileRef = 474EDB042E4BAA5E00E04760 /* FileCapturer.m */; };
+		474EDB052E4BAA5E00E04760 /* ImageCaptureController.m in Sources */ = {isa = PBXBuildFile; fileRef = 474EDB022E4BAA5E00E04760 /* ImageCaptureController.m */; };
+		474EDB062E4BAA5E00E04760 /* ImageCapturer.m in Sources */ = {isa = PBXBuildFile; fileRef = 474EDB042E4BAA5E00E04760 /* ImageCapturer.m */; };
 		4EC498BC25B8777F00E76218 /* ScreenCapturePickerViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EC498BA25B8777F00E76218 /* ScreenCapturePickerViewManager.m */; };
 		4EE3A8A325B840DA00FAA24A /* RCTConvert+WebRTC.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EE3A8A125B840DA00FAA24A /* RCTConvert+WebRTC.m */; };
 		4EE3A8A725B8411400FAA24A /* RTCMediaStreamTrack+React.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EE3A8A625B8411400FAA24A /* RTCMediaStreamTrack+React.m */; };
@@ -47,10 +47,10 @@
 		131131FC732883F1EF6F2CA3 /* Pods-RCTWebRTC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RCTWebRTC.release.xcconfig"; path = "Target Support Files/Pods-RCTWebRTC/Pods-RCTWebRTC.release.xcconfig"; sourceTree = "<group>"; };
 		1A7E646283326F2A95C8C1FA /* Pods-RCTWebRTC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RCTWebRTC.debug.xcconfig"; path = "Target Support Files/Pods-RCTWebRTC/Pods-RCTWebRTC.debug.xcconfig"; sourceTree = "<group>"; };
 		35A2221F1CB493700015FD5C /* libRCTWebRTC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTWebRTC.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		474EDB012E4BAA5E00E04760 /* FileCaptureController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FileCaptureController.h; path = RCTWebRTC/FileCaptureController.h; sourceTree = SOURCE_ROOT; };
-		474EDB022E4BAA5E00E04760 /* FileCaptureController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = FileCaptureController.m; path = RCTWebRTC/FileCaptureController.m; sourceTree = SOURCE_ROOT; };
-		474EDB032E4BAA5E00E04760 /* FileCapturer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FileCapturer.h; path = RCTWebRTC/FileCapturer.h; sourceTree = SOURCE_ROOT; };
-		474EDB042E4BAA5E00E04760 /* FileCapturer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = FileCapturer.m; path = RCTWebRTC/FileCapturer.m; sourceTree = SOURCE_ROOT; };
+		474EDB012E4BAA5E00E04760 /* ImageCaptureController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ImageCaptureController.h; path = RCTWebRTC/ImageCaptureController.h; sourceTree = SOURCE_ROOT; };
+		474EDB022E4BAA5E00E04760 /* ImageCaptureController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ImageCaptureController.m; path = RCTWebRTC/ImageCaptureController.m; sourceTree = SOURCE_ROOT; };
+		474EDB032E4BAA5E00E04760 /* ImageCapturer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ImageCapturer.h; path = RCTWebRTC/ImageCapturer.h; sourceTree = SOURCE_ROOT; };
+		474EDB042E4BAA5E00E04760 /* ImageCapturer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ImageCapturer.m; path = RCTWebRTC/ImageCapturer.m; sourceTree = SOURCE_ROOT; };
 		4EC498BA25B8777F00E76218 /* ScreenCapturePickerViewManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ScreenCapturePickerViewManager.m; path = RCTWebRTC/ScreenCapturePickerViewManager.m; sourceTree = SOURCE_ROOT; };
 		4EC498BB25B8777F00E76218 /* ScreenCapturePickerViewManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ScreenCapturePickerViewManager.h; path = RCTWebRTC/ScreenCapturePickerViewManager.h; sourceTree = SOURCE_ROOT; };
 		4EE3A8A125B840DA00FAA24A /* RCTConvert+WebRTC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RCTConvert+WebRTC.m"; path = "RCTWebRTC/RCTConvert+WebRTC.m"; sourceTree = SOURCE_ROOT; };
@@ -130,10 +130,10 @@
 		35A222311CB493C00015FD5C /* RCTWebRTC */ = {
 			isa = PBXGroup;
 			children = (
-				474EDB012E4BAA5E00E04760 /* FileCaptureController.h */,
-				474EDB022E4BAA5E00E04760 /* FileCaptureController.m */,
-				474EDB032E4BAA5E00E04760 /* FileCapturer.h */,
-				474EDB042E4BAA5E00E04760 /* FileCapturer.m */,
+				474EDB012E4BAA5E00E04760 /* ImageCaptureController.h */,
+				474EDB022E4BAA5E00E04760 /* ImageCaptureController.m */,
+				474EDB032E4BAA5E00E04760 /* ImageCapturer.h */,
+				474EDB042E4BAA5E00E04760 /* ImageCapturer.m */,
 				4EE3A8A225B840DA00FAA24A /* RCTConvert+WebRTC.h */,
 				4EE3A8A125B840DA00FAA24A /* RCTConvert+WebRTC.m */,
 				4EE3A8A525B8411400FAA24A /* RTCMediaStreamTrack+React.h */,
@@ -283,8 +283,8 @@
 				4EE3A8AC25B8412700FAA24A /* RTCVideoViewManager.m in Sources */,
 				4EE3A8C125B8416F00FAA24A /* WebRTCModule+RTCPeerConnection.m in Sources */,
 				4EE3A8A325B840DA00FAA24A /* RCTConvert+WebRTC.m in Sources */,
-				474EDB052E4BAA5E00E04760 /* FileCaptureController.m in Sources */,
-				474EDB062E4BAA5E00E04760 /* FileCapturer.m in Sources */,
+				474EDB052E4BAA5E00E04760 /* ImageCaptureController.m in Sources */,
+				474EDB062E4BAA5E00E04760 /* ImageCapturer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RCTWebRTC/ImageCaptureController.h
+++ b/ios/RCTWebRTC/ImageCaptureController.h
@@ -4,11 +4,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class FileCapturer;
+@class ImageCapturer;
 
-@interface FileCaptureController : CaptureController
+@interface ImageCaptureController : CaptureController
 
-- (instancetype)initWithCapturer:(nonnull FileCapturer *)capturer;
+- (instancetype)initWithCapturer:(nonnull ImageCapturer *)capturer;
 - (void)startCapture;
 - (void)stopCapture;
 

--- a/ios/RCTWebRTC/ImageCaptureController.m
+++ b/ios/RCTWebRTC/ImageCaptureController.m
@@ -1,25 +1,25 @@
 #if !TARGET_OS_TV
 
-#import "FileCaptureController.h"
-#import "FileCapturer.h"
+#import "ImageCaptureController.h"
+#import "ImageCapturer.h"
 
-@interface FileCaptureController ()
+@interface ImageCaptureController ()
 
-@property(nonatomic, retain) FileCapturer *capturer;
+@property(nonatomic, retain) ImageCapturer *capturer;
 
 @end
 
-@interface FileCaptureController (CapturerEventsDelegate)<CapturerEventsDelegate>
+@interface ImageCaptureController (CapturerEventsDelegate)<CapturerEventsDelegate>
 - (void)capturerDidEnd:(RTCVideoCapturer *)capturer;
 @end
 
-@implementation FileCaptureController
+@implementation ImageCaptureController
 
-- (instancetype)initWithCapturer:(nonnull FileCapturer *)capturer {
+- (instancetype)initWithCapturer:(nonnull ImageCapturer *)capturer {
     self = [super init];
     if (self) {
         self.capturer = capturer;
-        self.deviceId = @"file-capture";
+        self.deviceId = @"image-capture";
     }
 
     return self;

--- a/ios/RCTWebRTC/ImageCapturer.h
+++ b/ios/RCTWebRTC/ImageCapturer.h
@@ -4,7 +4,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FileCapturer : RTCVideoCapturer
+@interface ImageCapturer : RTCVideoCapturer
 
 @property(nonatomic, weak) id<CapturerEventsDelegate> eventsDelegate;
 

--- a/ios/RCTWebRTC/ImageCapturer.h
+++ b/ios/RCTWebRTC/ImageCapturer.h
@@ -4,6 +4,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void (^SuccessBlock)(UIImage *image);
+typedef void (^FailureBlock)(NSString *reason);
+
+void imageFromAsset(NSString *asset, SuccessBlock _Nullable success, FailureBlock _Nullable failure);
+
 @interface ImageCapturer : RTCVideoCapturer
 
 @property(nonatomic, weak) id<CapturerEventsDelegate> eventsDelegate;

--- a/ios/RCTWebRTC/ImageCapturer.h
+++ b/ios/RCTWebRTC/ImageCapturer.h
@@ -1,10 +1,11 @@
 #import <AVFoundation/AVFoundation.h>
 #import <WebRTC/RTCVideoCapturer.h>
+#import <WebRTC/RTCCVPixelBuffer.h>
 #import "CapturerEventsDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^SuccessBlock)(UIImage *image);
+typedef void (^SuccessBlock)(RTCCVPixelBuffer *image);
 typedef void (^FailureBlock)(NSString *reason);
 
 void imageFromAsset(NSString *asset, SuccessBlock _Nullable success, FailureBlock _Nullable failure);
@@ -13,7 +14,7 @@ void imageFromAsset(NSString *asset, SuccessBlock _Nullable success, FailureBloc
 
 @property(nonatomic, weak) id<CapturerEventsDelegate> eventsDelegate;
 
-- (instancetype)initWithDelegate:(__weak id<RTCVideoCapturerDelegate>)delegate asset:(NSString *)asset;
+- (instancetype)initWithDelegate:(__weak id<RTCVideoCapturerDelegate>)delegate image:(RTCCVPixelBuffer *)image;
 - (void)startCapture;
 - (void)stopCapture;
 

--- a/ios/RCTWebRTC/ImageCapturer.m
+++ b/ios/RCTWebRTC/ImageCapturer.m
@@ -14,6 +14,32 @@ static const NSTimeInterval kBurstInterval = 0.033;
 static const NSTimeInterval kSteadyInterval = 1.5;
 static const int64_t kBurstDuration = 3LL * NSEC_PER_SEC;
 
+void imageFromAsset(NSString *asset, SuccessBlock _Nullable success, FailureBlock _Nullable failure) {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        UIImage *localImage = [UIImage imageNamed:asset];
+        if (localImage != nil) {
+            dispatch_async(dispatch_get_main_queue(), ^{ if (success) success(localImage); });
+            return;
+        }
+        NSURL *url = [NSURL URLWithString: asset];
+        if (url == nil) {
+            dispatch_async(dispatch_get_main_queue(), ^{ if (failure) failure(@"invalid url"); });
+            return;
+        }
+        SDWebImageManager *imageManager = [SDWebImageManager sharedManager];
+        [imageManager loadImageWithURL:url
+                        options:0
+                        progress:nil
+                        completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+                          if (image && finished) {
+                            dispatch_async(dispatch_get_main_queue(), ^{ if (success) success(image); });
+                          } else {
+                            dispatch_async(dispatch_get_main_queue(), ^{ if (failure) failure(@"failed to load image"); });
+                          }
+        }];
+    });
+}
+
 RTCCVPixelBuffer *rtcPixelBufferFromUIImage(UIImage *image) {
   if (!image) {
     return nil;

--- a/ios/RCTWebRTC/ImageCapturer.m
+++ b/ios/RCTWebRTC/ImageCapturer.m
@@ -6,7 +6,7 @@
 #import <WebRTC/RTCCVPixelBuffer.h>
 #import <WebRTC/RTCVideoFrameBuffer.h>
 
-#import "FileCapturer.h"
+#import "ImageCapturer.h"
 
 #import <SDWebImage/SDWebImage.h>
 
@@ -80,7 +80,7 @@ RTCCVPixelBuffer *rtcPixelBufferFromUIImage(UIImage *image) {
   return rtcPixelBuffer;
 }
 
-@implementation FileCapturer {
+@implementation ImageCapturer {
     mach_timebase_info_data_t _timebaseInfo;
     int64_t _startTimeStampNs;
     NSTimer *_timer;

--- a/ios/RCTWebRTC/ImageCapturer.m
+++ b/ios/RCTWebRTC/ImageCapturer.m
@@ -3,7 +3,6 @@
 #include <mach/mach_time.h>
 
 #import <ReplayKit/ReplayKit.h>
-#import <WebRTC/RTCCVPixelBuffer.h>
 #import <WebRTC/RTCVideoFrameBuffer.h>
 
 #import "ImageCapturer.h"
@@ -13,32 +12,6 @@
 static const NSTimeInterval kBurstInterval = 0.033;
 static const NSTimeInterval kSteadyInterval = 1.5;
 static const int64_t kBurstDuration = 3LL * NSEC_PER_SEC;
-
-void imageFromAsset(NSString *asset, SuccessBlock _Nullable success, FailureBlock _Nullable failure) {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        UIImage *localImage = [UIImage imageNamed:asset];
-        if (localImage != nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{ if (success) success(localImage); });
-            return;
-        }
-        NSURL *url = [NSURL URLWithString: asset];
-        if (url == nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{ if (failure) failure(@"invalid url"); });
-            return;
-        }
-        SDWebImageManager *imageManager = [SDWebImageManager sharedManager];
-        [imageManager loadImageWithURL:url
-                        options:0
-                        progress:nil
-                        completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
-                          if (image && finished) {
-                            dispatch_async(dispatch_get_main_queue(), ^{ if (success) success(image); });
-                          } else {
-                            dispatch_async(dispatch_get_main_queue(), ^{ if (failure) failure(@"failed to load image"); });
-                          }
-        }];
-    });
-}
 
 RTCCVPixelBuffer *rtcPixelBufferFromUIImage(UIImage *image) {
   if (!image) {
@@ -106,48 +79,56 @@ RTCCVPixelBuffer *rtcPixelBufferFromUIImage(UIImage *image) {
   return rtcPixelBuffer;
 }
 
+void maybeLoadBuffer(UIImage *image, SuccessBlock _Nullable success, FailureBlock _Nullable failure) {
+    RTCCVPixelBuffer *buffer = rtcPixelBufferFromUIImage(image);
+    if (buffer != nil) {
+        dispatch_async(dispatch_get_main_queue(), ^{ if (success) success(buffer); });
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{ if (failure) failure(@"could not make buffer from image"); });
+    }
+}
+
+void imageFromAsset(NSString *asset, SuccessBlock _Nullable success, FailureBlock _Nullable failure) {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        UIImage *localImage = [UIImage imageNamed:asset];
+        if (localImage != nil) {
+            maybeLoadBuffer(localImage, success, failure);
+            return;
+        }
+        NSURL *url = [NSURL URLWithString: asset];
+        if (url == nil) {
+            dispatch_async(dispatch_get_main_queue(), ^{ if (failure) failure(@"invalid url"); });
+            return;
+        }
+        SDWebImageManager *imageManager = [SDWebImageManager sharedManager];
+        [imageManager loadImageWithURL:url
+                        options:0
+                        progress:nil
+                        completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+                          if (image && finished) {
+                            maybeLoadBuffer(image, success, failure);
+                          } else {
+                            dispatch_async(dispatch_get_main_queue(), ^{ if (failure) failure(@"failed to load image"); });
+                          }
+        }];
+    });
+}
+
 @implementation ImageCapturer {
     mach_timebase_info_data_t _timebaseInfo;
     int64_t _startTimeStampNs;
     NSTimer *_timer;
     RTCCVPixelBuffer *_rtcPixelBuffer;
-    SDWebImageCombinedOperation *_imageOperation;
     BOOL _bursting;
     BOOL _active;
 }
 
-- (instancetype)initWithDelegate:(__weak id<RTCVideoCapturerDelegate>)delegate asset:(NSString *)asset {
+- (instancetype)initWithDelegate:(__weak id<RTCVideoCapturerDelegate>)delegate image:(RTCCVPixelBuffer *)image {
     self = [super initWithDelegate:delegate];
     if (self) {
         mach_timebase_info(&_timebaseInfo);
     }
-
-    UIImage *localImage = [UIImage imageNamed:asset];
-    if (localImage != nil) {
-        _rtcPixelBuffer = rtcPixelBufferFromUIImage(localImage);
-    } else {
-      NSURL *url = [NSURL URLWithString: asset];
-      if (url != nil) {
-        SDWebImageManager *imageManager = [SDWebImageManager sharedManager];
-        __weak __typeof__(self) weakSelf = self;
-        _imageOperation = [imageManager loadImageWithURL:url
-                        options:0
-                        progress:nil
-                        completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
-                          __strong __typeof__(self) strongSelf = weakSelf;
-                          if (!strongSelf) {
-                            return;
-                          }
-                          if (image && finished) {
-                              strongSelf->_rtcPixelBuffer = rtcPixelBufferFromUIImage(image);
-                              if (strongSelf->_active) {
-                                [strongSelf startRenderLoop];
-                              }
-                          }
-        }];
-      }
-    }
-
+    _rtcPixelBuffer = image;
     return self;
 }
 
@@ -168,8 +149,6 @@ RTCCVPixelBuffer *rtcPixelBufferFromUIImage(UIImage *image) {
   _active = NO;
   [_timer invalidate];
   _timer = nil;
-  [_imageOperation cancel];
-  _imageOperation = nil;
 }
 
 - (void)startTimerWithInterval:(NSTimeInterval)interval {

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -218,7 +218,7 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
     return videoTrack;
 }
 
-- (void)makeImageStreamWithImage:(RTCCVPixelBuffer *) image resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject asset:(NSString *)asset {
+- (void)makeImageStreamWithImage:(RTCCVPixelBuffer *) image resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject {
     RTCVideoTrack *videoTrack = [self createImageCaptureVideoTrackWithImage:image];
 
     if (videoTrack == nil) {
@@ -248,7 +248,7 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
 RCT_EXPORT_METHOD(getFileMedia : (NSString *)asset resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     imageFromAsset(asset,
         ^(RTCCVPixelBuffer *image) {
-            [self makeImageStreamWithImage:image resolver:resolve rejecter:reject asset:asset];
+            [self makeImageStreamWithImage:image resolver:resolve rejecter:reject];
         },
         ^(NSString *failure) {
             reject(@"load_failure", failure, nil);

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -218,7 +218,7 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
     return videoTrack;
 }
 
-RCT_EXPORT_METHOD(getFileMedia : (NSString *)asset resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+- (void)makeImageStreamWithImage:(UIImage *) image resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject asset:(NSString *)asset {
     RTCVideoTrack *videoTrack = [self createImageCaptureVideoTrackWithAsset:asset];
 
     if (videoTrack == nil) {
@@ -243,6 +243,16 @@ RCT_EXPORT_METHOD(getFileMedia : (NSString *)asset resolver:(RCTPromiseResolveBl
 
     self.localStreams[mediaStreamId] = mediaStream;
     resolve(@{@"streamId" : mediaStreamId, @"track" : trackInfo});
+}
+
+RCT_EXPORT_METHOD(getFileMedia : (NSString *)asset resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    imageFromAsset(asset,
+        ^(UIImage *image) {
+            [self makeImageStreamWithImage:image resolver:resolve rejecter:reject asset:asset];
+        },
+        ^(NSString *failure) {
+            reject(@"load_failure", failure, nil);
+        });
 }
 
 /**

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -196,7 +196,7 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
 #endif
 }
 
-- (RTCVideoTrack *)createImageCaptureVideoTrackWithAsset:(NSString *)asset {
+- (RTCVideoTrack *)createImageCaptureVideoTrackWithImage:(RTCCVPixelBuffer *)image {
 #if TARGET_OS_TV
     return nil;
 #endif
@@ -206,7 +206,7 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
     NSString *trackUUID = [[NSUUID UUID] UUIDString];
     RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
 
-    ImageCapturer *imageCapturer = [[ImageCapturer alloc] initWithDelegate:videoSource asset:asset];
+    ImageCapturer *imageCapturer = [[ImageCapturer alloc] initWithDelegate:videoSource image:image];
     ImageCaptureController *imageCaptureController =
         [[ImageCaptureController alloc] initWithCapturer:imageCapturer];
 
@@ -218,8 +218,8 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
     return videoTrack;
 }
 
-- (void)makeImageStreamWithImage:(UIImage *) image resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject asset:(NSString *)asset {
-    RTCVideoTrack *videoTrack = [self createImageCaptureVideoTrackWithAsset:asset];
+- (void)makeImageStreamWithImage:(RTCCVPixelBuffer *) image resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject asset:(NSString *)asset {
+    RTCVideoTrack *videoTrack = [self createImageCaptureVideoTrackWithImage:image];
 
     if (videoTrack == nil) {
         reject(@"DOMException", @"AbortError", nil);
@@ -247,7 +247,7 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
 
 RCT_EXPORT_METHOD(getFileMedia : (NSString *)asset resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     imageFromAsset(asset,
-        ^(UIImage *image) {
+        ^(RTCCVPixelBuffer *image) {
             [self makeImageStreamWithImage:image resolver:resolve rejecter:reject asset:asset];
         },
         ^(NSString *failure) {

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -13,8 +13,8 @@
 #import "ProcessorProvider.h"
 #import "ScreenCaptureController.h"
 #import "ScreenCapturer.h"
-#import "FileCaptureController.h"
-#import "FileCapturer.h"
+#import "ImageCaptureController.h"
+#import "ImageCapturer.h"
 #import "TrackCapturerEventsEmitter.h"
 #import "VideoCaptureController.h"
 
@@ -196,7 +196,7 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
 #endif
 }
 
-- (RTCVideoTrack *)createFileCaptureVideoTrackWithAsset:(NSString *)asset {
+- (RTCVideoTrack *)createImageCaptureVideoTrackWithAsset:(NSString *)asset {
 #if TARGET_OS_TV
     return nil;
 #endif
@@ -206,20 +206,20 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
     NSString *trackUUID = [[NSUUID UUID] UUIDString];
     RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
 
-    FileCapturer *fileCapturer = [[FileCapturer alloc] initWithDelegate:videoSource asset:asset];
-    FileCaptureController *fileCaptureController =
-        [[FileCaptureController alloc] initWithCapturer:fileCapturer];
+    ImageCapturer *imageCapturer = [[ImageCapturer alloc] initWithDelegate:videoSource asset:asset];
+    ImageCaptureController *imageCaptureController =
+        [[ImageCaptureController alloc] initWithCapturer:imageCapturer];
 
     TrackCapturerEventsEmitter *emitter = [[TrackCapturerEventsEmitter alloc] initWith:trackUUID webRTCModule:self];
-    fileCaptureController.eventsDelegate = emitter;
-    videoTrack.captureController = fileCaptureController;
-    [fileCaptureController startCapture];
+    imageCaptureController.eventsDelegate = emitter;
+    videoTrack.captureController = imageCaptureController;
+    [imageCaptureController startCapture];
 
     return videoTrack;
 }
 
 RCT_EXPORT_METHOD(getFileMedia : (NSString *)asset resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-    RTCVideoTrack *videoTrack = [self createFileCaptureVideoTrackWithAsset:asset];
+    RTCVideoTrack *videoTrack = [self createImageCaptureVideoTrackWithAsset:asset];
 
     if (videoTrack == nil) {
         reject(@"DOMException", @"AbortError", nil);


### PR DESCRIPTION
Mainly to address silent failures and match WebRTC patterns.

Before, the loading was handled within the capturer. If the image failed to load for whatever reason, the track would still be "alive" and just be blank. Now, `getFileMedia` will be rejected if the buffer couldn't be made from the image asset.

Also changed the name from FileCapture(r) to ImageCapture(r). Keeping the `getFileMedia` in case we want to add a VideoCapture(r) at some point